### PR TITLE
Fix incorrect 0.0.0 version number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,16 @@ source:
 
 build:
   noarch: python
+  number: 1
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
 
 requirements:
   host:
     - pip
     - python >=3.8
+    - setuptools_scm
   run:
     - gitpython
     - python >=3.8


### PR DESCRIPTION
Fixes error like `dvc 0.0.0 has requirement dvc-studio-client>=0.1.1, but you have dvc-studio-client 0.0.0` due to `setuptools_scm` not getting the correct version number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Xref https://github.com/conda-forge/dvc-feedstock/pull/319#discussion_r1096962930
<!--
Please add any other relevant info below:
-->
Based on https://github.com/conda-forge/pygmt-feedstock/pull/15